### PR TITLE
Music restarted when starting charm

### DIFF
--- a/app/screens/Garden/CharmBookMenu/CharmBookMenu.tsx
+++ b/app/screens/Garden/CharmBookMenu/CharmBookMenu.tsx
@@ -23,6 +23,7 @@ import {
   CharmBookMenuType,
   ICharmBookMenuScreenProps,
 } from './CharmBookMenu.types';
+import { AudioPlayerHelper } from '../../../services/helpers/AudioPlayerHelper';
 
 const WhiteBackArrowIcon = SVG.WhiteBackArrowIcon;
 const OpenBookIcon = SVG.OpenBookIcon;
@@ -31,6 +32,13 @@ export const CharmBookMenuScreen: React.FC<ICharmBookMenuScreenProps> = ({
   type,
   setModalStatus,
 }) => {
+  const isBackgroundMusicEnabled = useAppSelector(
+    state => state.settings.settings.audioSettings?.isBackgroundMusicEnabled,
+  );
+  const backgroundAudio = useAppSelector(
+    state => state.cache.backgroundAudio ?? null,
+  );
+
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const navigation = useNavigation<StackNavigationProp<MergedStackParams>>();
@@ -78,9 +86,16 @@ export const CharmBookMenuScreen: React.FC<ICharmBookMenuScreenProps> = ({
         default:
           audioPath = AUDIO.FOREST_AMBIENCE_LOOP;
       }
-      dispatch(cacheSlice.actions.setBackgroundAudio(audioPath));
+
+      if (isBackgroundMusicEnabled) {
+        if (backgroundAudio !== audioPath) {
+          dispatch(cacheSlice.actions.setBackgroundAudio(audioPath));
+        } else {
+          AudioPlayerHelper.startInfiniteLoop();
+        }
+      }
     },
-    [dispatch],
+    [dispatch, isBackgroundMusicEnabled, backgroundAudio],
   );
 
   const onPlayPress = useCallback(() => {


### PR DESCRIPTION
When starting some charms, there would be no background music. This was caused by the music being controlled outside of the global music state. The code I've put in restarts the music when the user presses play to start a charm. Although this has fixed the immediate issue, the music implementation will need a complete overhaul and rewriting in the future as there are too many tangential implementations controlling the music which has introduced many bugs.