### PR TITLE
Save screen location on local storage

### DIFF
--- a/app/navigation/navigationAsyncStorage.ts
+++ b/app/navigation/navigationAsyncStorage.ts
@@ -1,0 +1,20 @@
+import AsyncStorage from '@react-native-community/async-storage';
+
+const recognitionStackScreen = 'recognition_stack_screen';
+const mainStack = 'main_stack';
+
+export const SaveRecognitionStackScreenName = async (screen: string) => {
+  await AsyncStorage.setItem(recognitionStackScreen, screen);
+};
+
+export const GetRecognitionStackScreenName = async () => {
+  return await AsyncStorage.getItem(recognitionStackScreen);
+};
+
+export const SaveMainStackName = async (screen: string) => {
+  await AsyncStorage.setItem(mainStack, screen);
+};
+
+export const GetMainStackName = async () => {
+  return await AsyncStorage.getItem(mainStack);
+};

--- a/app/navigation/rootNavigator.tsx
+++ b/app/navigation/rootNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 import {
   NavigationContainer,
@@ -31,6 +31,7 @@ import { InitialScreen } from '../screens';
 import { navigationRef } from '../services/navigator';
 import { GLOBAL_NAVIGATION_STACK_OPTIONS } from './options';
 import { trackScreenView } from '../services/firebase';
+import { GetMainStackName } from './navigationAsyncStorage';
 
 export type RootParams = {
   Initial: undefined;
@@ -57,6 +58,24 @@ const Stack = createNativeStackNavigator<RootParams>();
 const RootNavigator = () => {
   const routeNameRef = useRef<string>();
 
+  const [initialRoute, setInitialRoute] = useState<
+    keyof RootParams | undefined
+  >();
+
+  useEffect(() => {
+    const getMainStack = async () => {
+      const mainNavigationStack =
+        (await GetMainStackName()) as keyof RootParams;
+      if (mainNavigationStack) {
+        setInitialRoute(mainNavigationStack);
+      } else {
+        setInitialRoute('Initial');
+      }
+    };
+    getMainStack();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <NavigationContainer
       ref={navigationRef}
@@ -72,40 +91,44 @@ const RootNavigator = () => {
           trackScreenView(currentRouteName, currentRouteName);
         }
       }}>
-      <Stack.Navigator screenOptions={GLOBAL_NAVIGATION_STACK_OPTIONS}>
-        <Stack.Screen name="Initial" component={InitialScreen} />
-        <Stack.Screen
-          name="ParentsOnboardingStack"
-          component={ParentsOnboardingStackNavigator}
-        />
-        <Stack.Screen
-          name="JointOnboardingStack"
-          component={JointOnboardingStackNavigator}
-        />
-        <Stack.Screen
-          name="RecognitionStack"
-          component={RecognitionStackNavigator}
-        />
-        <Stack.Screen name="MenuStack" component={MenuStackNavigator} />
-        <Stack.Screen name="QuestStack" component={QuestStackNavigator} />
-        <Stack.Screen
-          name="MixingElixirStack"
-          component={MixingElixirStackNavigator}
-        />
-        <Stack.Screen name="GardenStack" component={GardenStackNavigator} />
-        <Stack.Screen
-          name="ParentGroundingStack"
-          component={ParentGroundingStackNavigator}
-        />
-        <Stack.Screen
-          name="BefriendingStack"
-          component={BefriendingStackNavigator}
-        />
-        <Stack.Screen
-          name="EditProfileStack"
-          component={EditProfileStackNavigator}
-        />
-      </Stack.Navigator>
+      {initialRoute ? (
+        <Stack.Navigator
+          screenOptions={GLOBAL_NAVIGATION_STACK_OPTIONS}
+          initialRouteName={initialRoute}>
+          <Stack.Screen name="Initial" component={InitialScreen} />
+          <Stack.Screen
+            name="ParentsOnboardingStack"
+            component={ParentsOnboardingStackNavigator}
+          />
+          <Stack.Screen
+            name="JointOnboardingStack"
+            component={JointOnboardingStackNavigator}
+          />
+          <Stack.Screen
+            name="RecognitionStack"
+            component={RecognitionStackNavigator}
+          />
+          <Stack.Screen name="MenuStack" component={MenuStackNavigator} />
+          <Stack.Screen name="QuestStack" component={QuestStackNavigator} />
+          <Stack.Screen
+            name="MixingElixirStack"
+            component={MixingElixirStackNavigator}
+          />
+          <Stack.Screen name="GardenStack" component={GardenStackNavigator} />
+          <Stack.Screen
+            name="ParentGroundingStack"
+            component={ParentGroundingStackNavigator}
+          />
+          <Stack.Screen
+            name="BefriendingStack"
+            component={BefriendingStackNavigator}
+          />
+          <Stack.Screen
+            name="EditProfileStack"
+            component={EditProfileStackNavigator}
+          />
+        </Stack.Navigator>
+      ) : null}
     </NavigationContainer>
   );
 };

--- a/app/navigation/stacks/gardenStackNavigator.tsx
+++ b/app/navigation/stacks/gardenStackNavigator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 
 import {
@@ -14,6 +14,10 @@ import {
   SkipCharmJournalScreen,
 } from '../../screens';
 import { DEFAULT_STACK_OPTIONS } from '../options';
+import {
+  SaveMainStackName,
+  SaveRecognitionStackScreenName,
+} from '../navigationAsyncStorage';
 
 export type GardenStackParams = {
   Garden: {
@@ -33,41 +37,54 @@ export type GardenStackParams = {
 
 const Stack = createNativeStackNavigator<GardenStackParams>();
 
-export const GardenStackNavigator = () => (
-  <Stack.Navigator screenOptions={DEFAULT_STACK_OPTIONS}>
-    <Stack.Screen
-      name="Garden"
-      component={GardenScreen}
-      initialParams={{
-        isPlanting: false,
-        isFirstTime: false,
-        isFirstTimeGarden: false,
-      }}
-    />
-    <Stack.Screen
-      name="GardenTutorialDialog"
-      component={GardenTutorialDialogScreen}
-      initialParams={{ isStart: true }}
-    />
-    <Stack.Screen name="CharmBookMenu" component={CharmBookMenuScreen} />
-    <Stack.Screen
-      name="SelectCharmCarousel"
-      component={SelectCharmCarouselScreen}
-    />
-    <Stack.Screen
-      name="CompletedCharmEnd"
-      component={CompletedCharmEndScreen}
-    />
+export const GardenStackNavigator = () => {
+  useEffect(() => {
+    const saveStack = async () => {
+      await SaveMainStackName('');
+      await SaveRecognitionStackScreenName('');
+    };
+    saveStack();
+  }, []);
 
-    <Stack.Screen name="SkipCharmAlert" component={SkipCharmAlertScreen} />
-    <Stack.Screen
-      name="SkipCharmAcknowledgement"
-      component={SkipCharmAcknowledgementScreen}
-    />
-    <Stack.Screen
-      name="SkipCharmEmojiSelection"
-      component={SkipCharmEmojiSelectionScreen}
-    />
-    <Stack.Screen name="SkipCharmJournal" component={SkipCharmJournalScreen} />
-  </Stack.Navigator>
-);
+  return (
+    <Stack.Navigator screenOptions={DEFAULT_STACK_OPTIONS}>
+      <Stack.Screen
+        name="Garden"
+        component={GardenScreen}
+        initialParams={{
+          isPlanting: false,
+          isFirstTime: false,
+          isFirstTimeGarden: false,
+        }}
+      />
+      <Stack.Screen
+        name="GardenTutorialDialog"
+        component={GardenTutorialDialogScreen}
+        initialParams={{ isStart: true }}
+      />
+      <Stack.Screen name="CharmBookMenu" component={CharmBookMenuScreen} />
+      <Stack.Screen
+        name="SelectCharmCarousel"
+        component={SelectCharmCarouselScreen}
+      />
+      <Stack.Screen
+        name="CompletedCharmEnd"
+        component={CompletedCharmEndScreen}
+      />
+
+      <Stack.Screen name="SkipCharmAlert" component={SkipCharmAlertScreen} />
+      <Stack.Screen
+        name="SkipCharmAcknowledgement"
+        component={SkipCharmAcknowledgementScreen}
+      />
+      <Stack.Screen
+        name="SkipCharmEmojiSelection"
+        component={SkipCharmEmojiSelectionScreen}
+      />
+      <Stack.Screen
+        name="SkipCharmJournal"
+        component={SkipCharmJournalScreen}
+      />
+    </Stack.Navigator>
+  );
+};

--- a/app/navigation/stacks/recognitionStackNavigator.tsx
+++ b/app/navigation/stacks/recognitionStackNavigator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 
 import {
@@ -12,6 +12,10 @@ import {
   RecognitionDoubleInteractionSuccessScreen,
 } from '../../screens';
 import { DEFAULT_STACK_OPTIONS } from '../options';
+import {
+  GetRecognitionStackScreenName,
+  SaveMainStackName,
+} from '../navigationAsyncStorage';
 
 export type RecognitionStackParams = {
   RecognitionDialog: { data: IRecognitionDialogRoute };
@@ -24,25 +28,59 @@ export type RecognitionStackParams = {
 
 const Stack = createNativeStackNavigator<RecognitionStackParams>();
 
-export const RecognitionStackNavigator = () => (
-  <Stack.Navigator screenOptions={DEFAULT_STACK_OPTIONS}>
-    <Stack.Screen
-      name="RecognitionDialog"
-      component={RecognitionDialogScreen}
-    />
-    <Stack.Screen name="ChooseReason" component={ChooseReasonScreen} />
-    <Stack.Screen
-      name="RecognitionAcknowledgement"
-      component={RecognitionAcknowledgementScreen}
-    />
-    <Stack.Screen name="ElixirCarousel" component={ElixirCarouselScreen} />
-    <Stack.Screen
-      name="RecognitionDoubleInteraction"
-      component={RecognitionDoubleInteractionScreen}
-    />
-    <Stack.Screen
-      name="RecognitionDoubleInteractionSuccess"
-      component={RecognitionDoubleInteractionSuccessScreen}
-    />
-  </Stack.Navigator>
-);
+export const RecognitionStackNavigator = () => {
+  const [currentRouteName, setCurrentRouteName] = useState<
+    keyof RecognitionStackParams | undefined
+  >();
+
+  useEffect(() => {
+    const saveStack = async () => {
+      await SaveMainStackName('RecognitionStack');
+    };
+    saveStack();
+  }, []);
+
+  useEffect(() => {
+    const getStackScreen = async () => {
+      const route = await GetRecognitionStackScreenName();
+      if (route) {
+        setCurrentRouteName(route as keyof RecognitionStackParams);
+      } else {
+        setCurrentRouteName('RecognitionDialog');
+      }
+    };
+    getStackScreen();
+  }, []);
+
+  return (
+    <>
+      {currentRouteName ? (
+        <Stack.Navigator
+          screenOptions={DEFAULT_STACK_OPTIONS}
+          initialRouteName={currentRouteName}>
+          <Stack.Screen
+            name="RecognitionDialog"
+            component={RecognitionDialogScreen}
+          />
+          <Stack.Screen name="ChooseReason" component={ChooseReasonScreen} />
+          <Stack.Screen
+            name="RecognitionAcknowledgement"
+            component={RecognitionAcknowledgementScreen}
+          />
+          <Stack.Screen
+            name="ElixirCarousel"
+            component={ElixirCarouselScreen}
+          />
+          <Stack.Screen
+            name="RecognitionDoubleInteraction"
+            component={RecognitionDoubleInteractionScreen}
+          />
+          <Stack.Screen
+            name="RecognitionDoubleInteractionSuccess"
+            component={RecognitionDoubleInteractionSuccessScreen}
+          />
+        </Stack.Navigator>
+      ) : null}
+    </>
+  );
+};

--- a/app/screens/Recognition/ChooseReason/ChooseReason.tsx
+++ b/app/screens/Recognition/ChooseReason/ChooseReason.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ImageBackground, Pressable, SafeAreaView, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -16,13 +16,23 @@ import { CHOOSE_REASON_DATA } from './ChooseReason.data';
 import { RecognitionAcknowledgementType } from '../RecognitionAcknowledgement/RecognitionAcknowledgement.data';
 import { SVG } from '../../../assets/svg';
 import { BACKGROUND_IMAGES } from '../../../assets';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 const WhiteBackArrowIcon = SVG.WhiteBackArrowIcon;
 
 export const ChooseReasonScreen: React.FC<IChooseReasonScreenProps> = ({
   navigation,
+  route,
 }) => {
   const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => {
+    const saveStackScreenName = async () => {
+      await SaveRecognitionStackScreenName(route.name);
+    };
+    saveStackScreenName();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { t } = useTranslation();
 

--- a/app/screens/Recognition/ElixirCarousel/ElixirCarousel.tsx
+++ b/app/screens/Recognition/ElixirCarousel/ElixirCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ImageBackground, SafeAreaView } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ICarouselInstance } from 'react-native-reanimated-carousel';
@@ -9,13 +9,23 @@ import { styles } from './ElixirCarousel.styles';
 import { BottomButtonView, Carousel, CarouselType } from '../../../components';
 import { generalStyles } from '../../../utils/styles';
 import { BACKGROUND_IMAGES } from '../../../assets';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 export const ElixirCarouselScreen: React.FC<IElixirCarouselScreenProps> = ({
   navigation,
+  route,
 }) => {
   const { t } = useTranslation();
   const [index, setIndex] = useState(0);
   const carouselRef = useRef<ICarouselInstance>(null);
+
+  useEffect(() => {
+    const saveStackScreenName = async () => {
+      await SaveRecognitionStackScreenName(route.name);
+    };
+    saveStackScreenName();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onSubmitPress = useCallback(() => {
     if (index >= ELIXIR_CAROUSEL.length - 1) {

--- a/app/screens/Recognition/RecognitionAcknowledgement/RecognitionAcknowledgement.tsx
+++ b/app/screens/Recognition/RecognitionAcknowledgement/RecognitionAcknowledgement.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { ImageBackground, SafeAreaView, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -16,6 +16,7 @@ import { RECOGNITION_ACKNOWLEDGEMENT_DATA } from './RecognitionAcknowledgement.d
 import { useParsedJSXTextNickname } from '../../../hooks';
 import { SPIRIT_INTRO_DIALOG } from '../RecognitionDialog/RecognitionDialog.data';
 import { SVG } from '../../../assets/svg';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 const WhiteBackArrowIcon = SVG.WhiteBackArrowIcon;
 const CompassionateGuideIcon = SVG.CompassionateGuideIcon;
@@ -23,6 +24,14 @@ const CompassionateGuideIcon = SVG.CompassionateGuideIcon;
 export const RecognitionAcknowledgementScreen: React.FC<IRecognitionAcknowledgementScreenProps> =
   ({ navigation, route }) => {
     const { type } = route.params.data;
+
+    useEffect(() => {
+      const saveStackScreenName = async () => {
+        await SaveRecognitionStackScreenName(route.name);
+      };
+      saveStackScreenName();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const { t } = useTranslation();
 

--- a/app/screens/Recognition/RecognitionDialog/RecognitionDialog.tsx
+++ b/app/screens/Recognition/RecognitionDialog/RecognitionDialog.tsx
@@ -1,13 +1,22 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { DialogView } from '../../../components';
 import { RECOGNITION_DIALOG_DATA } from './RecognitionDialog.data';
 import { IRecognitionDialogScreenProps } from './RecognitionDialog.types';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 export const RecognitionDialogScreen: React.FC<IRecognitionDialogScreenProps> =
   ({ navigation, route }) => {
     const speech = route.params?.data.speech ?? RECOGNITION_DIALOG_DATA;
     const nextRoute = route.params?.data.nextRoute ?? 'ChooseReason';
+
+    useEffect(() => {
+      const saveStackScreenName = async () => {
+        await SaveRecognitionStackScreenName(route.name);
+      };
+      saveStackScreenName();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const onSubmit = useCallback(() => {
       navigation.navigate(nextRoute);

--- a/app/screens/Recognition/RecognitionDoubleInteraction/RecognitionDoubleInteraction.tsx
+++ b/app/screens/Recognition/RecognitionDoubleInteraction/RecognitionDoubleInteraction.tsx
@@ -20,13 +20,22 @@ import { LottieAbsoluteStyles } from '../../../utils';
 import { generalStyles } from '../../../utils/styles';
 import { styles } from './RecognitionDoubleInteraction.styles';
 import { IRecognitionDoubleInteractionScreenProps } from './RecognitionDoubleInteraction.types';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 export const RecognitionDoubleInteractionScreen: React.FC<IRecognitionDoubleInteractionScreenProps> =
-  ({ navigation }) => {
+  ({ navigation, route }) => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
     const appStatus = useAppState();
     const animationRef = useRef<Lottie>(null);
+
+    useEffect(() => {
+      const saveStackScreenName = async () => {
+        await SaveRecognitionStackScreenName(route.name);
+      };
+      saveStackScreenName();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     useInternetCheck(
       'errors.network_progress.title',

--- a/app/screens/Recognition/RecognitionDoubleInteractionSuccess/RecognitionDoubleInteractionSuccess.tsx
+++ b/app/screens/Recognition/RecognitionDoubleInteractionSuccess/RecognitionDoubleInteractionSuccess.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ImageBackground, SafeAreaView } from 'react-native';
 import Lottie from 'lottie-react-native';
@@ -10,10 +10,19 @@ import { LottieAbsoluteStyles } from '../../../utils';
 import { generalStyles } from '../../../utils/styles';
 import { GARDEN_TRANSSITION_DIALOG } from '../RecognitionDialog/RecognitionDialog.data';
 import { IRecognitionDoubleInteractionSuccessScreenProps } from './RecognitionDoubleInteractionSuccess.types';
+import { SaveRecognitionStackScreenName } from '../../../navigation/navigationAsyncStorage';
 
 export const RecognitionDoubleInteractionSuccessScreen: React.FC<IRecognitionDoubleInteractionSuccessScreenProps> =
-  ({ navigation }) => {
+  ({ navigation, route }) => {
     const { t } = useTranslation();
+
+    useEffect(() => {
+      const saveStackScreenName = async () => {
+        await SaveRecognitionStackScreenName(route.name);
+      };
+      saveStackScreenName();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const onSubmitPress = useCallback(() => {
       navigation.push('RecognitionDialog', {


### PR DESCRIPTION
Currently, if the user closes the app while on the "What brought you here?" screen, reopening the app causes it to jump directly to the "FTUE Garden Narrative" section, skipping the "Troublesome Spirit introduction" and "Potion carousel" sections. This task involves addressing the issue to ensure that when the app is reopened after being closed in the "What brought you here?" screen, it resumes from the same screen.